### PR TITLE
WS clean-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/)
 
+## [2.0.4] - 2026-06-02
+
+Revert sente to v1.17.0
+
 ## [2.0.3] - 2026-05-13
 
 Support configuring all HttpCompliance modes.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.factorhouse/slipway-jetty12 "2.0.3"
+(defproject io.factorhouse/slipway-jetty12 "2.0.4"
 
   :description "A Clojure Companion for Jetty 12.1"
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :license {:name "Apache 2.0 License"
             :url  "https://github.com/factorhouse/slipway/blob/main/LICENSE"}
 
-  :profiles {:dev      {:dependencies   [[clj-kondo "2026.04.15"]
+  :profiles {:dev      {:dependencies   [[clj-kondo "2026.04.15" :exclusions [org.clojure/tools.reader]] ;; conflict with sente
                                          [clj-http "3.13.1" :exclusions [commons-io]] ;; later version in reitit-ring
                                          [ch.qos.logback/logback-classic "1.5.32"]
                                          [hiccup "2.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
   :dependencies [[org.clojure/clojure "1.12.4"]
                  [org.clojure/tools.logging "1.3.1"]
                  [org.ring-clojure/ring-core-protocols "1.15.4"]
-                 [com.taoensso/sente "1.21.0"]
+                 [com.taoensso/sente "1.17.0"]
                  [org.eclipse.jetty.websocket/jetty-websocket-jetty-api "12.1.9"]
                  [org.eclipse.jetty.websocket/jetty-websocket-jetty-server "12.1.9"]
                  [org.eclipse.jetty/jetty-server "12.1.9"]

--- a/src/slipway.clj
+++ b/src/slipway.clj
@@ -81,14 +81,14 @@
 
   #:slipway.websockets{:enabled?                 "are websockets enabled? default true"
                        :path-spec                "the websocket path-spec, default '/chsk'"
-                       :idle-timeout-ms          "max websocket idle time, default 500000"
+                       :idle-timeout-ms          "max websocket idle time, default 300000"
                        :input-buffer-bytes       "max websocket input buffer size"
                        :output-buffer-bytes      "max websocket output buffer size"
-                       :max-text-message-bytes   "max websocket text message size"
-                       :max-binary-message-bytes "max websocket binary message size"
+                       :max-text-message-bytes   "max websocket text message size that can be received"
+                       :max-binary-message-bytes "max websocket binary message size that can be received"
                        :max-frame-bytes          "max websocket frame size"
-                       :max-outgoing-frames      "max websocket frames waiting to be sent per session, default 50"
-                       :auto-fragment            "websocket auto fragment (boolean)"}
+                       :max-outgoing-frames      "max websocket frames waiting to be sent per session, default -1"
+                       :auto-fragment            "websocket auto fragment (boolean), default true"}
 
   #:slipway.handler{:context-path    "the root context path, default '/'"
                     :ws-path         "the path serving the websocket upgrade handler, default '/chsk'"

--- a/src/slipway/websockets.clj
+++ b/src/slipway/websockets.clj
@@ -43,22 +43,21 @@
 (comment
   #:slipway.websockets{:enabled?                 "are websockets enabled? default true"
                        :path-spec                "the websocket path-spec, default '/chsk'"
-                       :idle-timeout-ms          "max websocket idle time, default 500000"
+                       :idle-timeout-ms          "max websocket idle time, default 300000"
                        :input-buffer-bytes       "max websocket input buffer size"
                        :output-buffer-bytes      "max websocket output buffer size"
-                       :max-text-message-bytes   "max websocket text message size"
-                       :max-binary-message-bytes "max websocket binary message size"
+                       :max-text-message-bytes   "max websocket text message size that can be received"
+                       :max-binary-message-bytes "max websocket binary message size that can be received"
                        :max-frame-bytes          "max websocket frame size"
-                       :max-outgoing-frames      "max websocket frames waiting to be sent per session, default 50"
-                       :auto-fragment            "websocket auto fragment (boolean)"})
+                       :max-outgoing-frames      "max websocket frames waiting to be sent per session, default -1"
+                       :auto-fragment            "websocket auto fragment (boolean), default true"})
 
 (defn handler ^WebSocketUpgradeHandler
   [^Server server ^ContextHandler handler ring-handler opts]
   (let [{::keys [enabled? path-spec idle-timeout-ms input-buffer-bytes output-buffer-bytes max-text-message-bytes
                  max-binary-message-bytes max-frame-bytes max-outgoing-frames auto-fragment]
          :or    {path-spec           "/chsk"
-                 idle-timeout-ms     500000
-                 max-outgoing-frames 50}} opts]
+                 idle-timeout-ms     300000}} opts]
     (when (not (false? enabled?))
       (log/debugf "configuring websockets at %s with %s" path-spec opts)
       (WebSocketUpgradeHandler/from


### PR DESCRIPTION
* Revert sente to 1.17.0 (same as previous Slipway 1.x)
* Clarify ws settings/comments
* Adjust default ws-timeout to 5min
* Remove default 50 max-outgoing-frames