### PR TITLE
Improve websocket error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/)
 
+## [2.0.6] - 2026-06-03
+
+* Reduce websocket error logs to simply type/message rather than full stacktrace
+
 ## [2.0.5] - 2026-06-02
 
 * Log Jetty websocket errors at ERROR level (up from DEBUG)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.factorhouse/slipway-jetty12 "2.0.5"
+(defproject io.factorhouse/slipway-jetty12 "2.0.6"
 
   :description "A Clojure Companion for Jetty 12.1"
 

--- a/src/slipway/websockets.clj
+++ b/src/slipway/websockets.clj
@@ -21,7 +21,10 @@
         (reset! session nil)
         (when cb (.succeed cb)))
       (^void onWebSocketError [_ ^Throwable error]
-        (log/error "websocket error" error))
+       ;; We choose to log the error type/message without the stacktrace here, these can be quite insignificant and
+       ;; can cause a lot of chat in the logs, particularly ChannelClosedExceptions which can happen as a normal 
+       ;; part of user interaction (hard shutting the browser tab).
+        (log/error "websocket error" (some-> error (.toString))))
       (^void onWebSocketText [_ ^String message]
         (on-message @session message))
       (^void onWebSocketBinary [_ ^ByteBuffer payload ^Callback cb]
@@ -53,8 +56,8 @@
   [^Server server ^ContextHandler handler ring-handler opts]
   (let [{::keys [enabled? path-spec idle-timeout-ms input-buffer-bytes output-buffer-bytes max-text-message-bytes
                  max-binary-message-bytes max-frame-bytes max-outgoing-frames auto-fragment]
-         :or    {path-spec           "/chsk"
-                 idle-timeout-ms     300000}} opts]
+         :or    {path-spec       "/chsk"
+                 idle-timeout-ms 300000}} opts]
     (when (not (false? enabled?))
       (log/debugf "configuring websockets at %s with %s" path-spec opts)
       (WebSocketUpgradeHandler/from


### PR DESCRIPTION
Errors at the websocket level can be quite chatty, so we log (at ERROR level all the same) only the type/message of the error, not the stacktrace. They're all signals of things like MessageTooLargeException or similar anyway.