### PR TITLE
Rename :slipway.security.oidc.jwt.at.verification configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/)
 
+## [2.1.4] - 2026-09-07
+
+* Rename `:slipway.security.oidc.jwt.at.verification` configuration
+
 ## [2.1.3] - 2026-09-07
 
-* Rename :slipway.security.oidc.jwks/endpoint > :slipway.security.oidc.jwks/uri
+* Rename `:slipway.security.oidc.jwks/endpoint` > `:slipway.security.oidc.jwks/uri`
 
 ## [2.1.2] - 2026-09-07
 

--- a/README.md
+++ b/README.md
@@ -792,16 +792,16 @@ algorithm or algorithms that can apply when validating the provided access-token
 ### [ns: slipway.security.oidc.jwt.at.verification](src/slipway/security/oidc/jwt/at/verification.clj)
 
 When implementing `Client Credentials Flow` for OIDC, it is necessary to specify how the access-token should be
-verified. This configuration gives you the flexibility required to ensure the access-token isl reliable.
+verified. This configuration gives you the flexibility required to ensure the access-token is valid.
 
 #### slipway.security.oidc.jwt.at.verification configuration
 
 ```clojure
 #:slipway.security.oidc.jwt.at.verification
-        {::exact-typ       "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
-         ::exact-iss       "required: the URL of the OIDC provider"
-         ::exact-aud       "required: the audience of this service to match the 'aud' field in the jwt"
-         ::required-claims "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
+        {::allowed-types     "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
+         ::required-issuer   "required: the URL of the OIDC provider"
+         ::required-audience "required: the audience of this service to match the 'aud' field in the jwt"
+         ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
 ```
 
 ### [ns: slipway.security.oidc.jwk](src/slipway/security/oidc/jwks.clj)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.factorhouse/slipway-jetty12 "2.1.3"
+(defproject io.factorhouse/slipway-jetty12 "2.1.4"
 
   :description "A Clojure Companion for Jetty 12.1"
 

--- a/src/slipway.clj
+++ b/src/slipway.clj
@@ -128,10 +128,10 @@
                               :user-id-path           "the path within the source token to find user name, default is ['sub']"
                               :user-expiration-source "the token used for session expiration, either 'access_token' or 'id_token' (default is 'access_token')"}
 
-  #:slipway.security.oidc.jwt.at.verification{::exact-typ       "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
-                                              ::exact-iss       "required: the URL of the OIDC provider"
-                                              ::exact-aud       "required: the audience of this service to match the 'aud' field in the jwt"
-                                              ::required-claims "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
+  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
+                                              ::required-issuer   "required: the URL of the OIDC provider"
+                                              ::required-audience "required: the audience of this service to match the 'aud' field in the jwt"
+                                              ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
 
   #:slipway.session{:enabled?                "are sessions enabled for this server? Default true"
                     :secure-request-only?    "set the secure flag on session cookies"

--- a/src/slipway/security/oidc/jwt/at/verification.clj
+++ b/src/slipway/security/oidc/jwt/at/verification.clj
@@ -7,7 +7,6 @@
            (java.util Set)))
 
 ;; https://datatracker.ietf.org/doc/html/rfc9068#section-2.1
-
 ;; typ MUST conform to "application/at+jwt", RECOMMENDED that "application/" be ommitted
 ;; Keycloak (and possibly other IdP) encodes "JWT" at token type, you can encode that here or:
 ;;  - https://www.keycloak.org/2025/04/keycloak-2620-released
@@ -15,31 +14,31 @@
 ;;  - set "access.token.header.type.rfc9068": "true" in ["client" "attributes"] to have Keycloak conform to the RFC
 
 (defn type-verifier ^JOSEObjectTypeVerifier
-  [{::keys [exact-typ]
-    :or    {exact-typ ["at+jwt" "application/at+jwt"]}}]
-  (let [^Set object-types-set (set (map #(JOSEObjectType. %1) exact-typ))]
-    (log/debugf "creating type-verifier with types %s" (mapv #(.getType %1) object-types-set))
+  [{::keys [allowed-types]
+    :or    {allowed-types ["at+jwt" "application/at+jwt"]}}]
+  (let [^Set object-types-set (set (map #(JOSEObjectType. %1) allowed-types))]
+    (log/debugf "creating type-verifier with allowed types %s" (mapv #(.getType %1) object-types-set))
     (DefaultJOSEObjectTypeVerifier. object-types-set)))
 
 (defn claims-verifier
   "A claims verifier for OAuth 2.0 access tokens"
-  [{::keys [exact-iss exact-aud required-claims]
+  [{::keys [required-issuer required-audience required-claims]
     :or    {required-claims #{JWTClaimNames/JWT_ID
                               JWTClaimNames/SUBJECT
                               JWTClaimNames/ISSUED_AT
                               JWTClaimNames/EXPIRATION_TIME}}}]
-  (when-not exact-iss (throw (ex-info "missing required configuration: exact-iss" {})))
-  (when-not exact-aud (throw (ex-info "missing required configuration: exact-aud" {})))
-  (log/debugf "creating claims-verifier for issuer %s and aud %s" exact-iss exact-aud)
+  (when-not required-issuer (throw (ex-info "missing required configuration: required-issuer" {})))
+  (when-not required-audience (throw (ex-info "missing required configuration: required-audience" {})))
+  (log/debugf "creating claims-verifier for issuer %s and audience %s" required-issuer required-audience)
   (DefaultJWTClaimsVerifier.
-   exact-aud
+   required-audience
    (-> (JWTClaimsSet$Builder.)
-       (.issuer exact-iss)
+       (.issuer required-issuer)
        (.build))
    required-claims))
 
 (comment
-  #:slipway.security.oidc.jwt.at.verification{::exact-typ       "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
-                                              ::exact-iss       "required: the URL of the OIDC provider"
-                                              ::exact-aud       "required: the audience of this service to match the 'aud' field in the jwt"
-                                              ::required-claims "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"})
+  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
+                                              ::required-issuer   "required: the URL of the OIDC provider"
+                                              ::required-audience "required: the audience of this service to match the 'aud' field in the jwt"
+                                              ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"})

--- a/test/integration/slipway/security/oidc_client_credentials_test.clj
+++ b/test/integration/slipway/security/oidc_client_credentials_test.clj
@@ -51,15 +51,15 @@
 
       (test-server/start!
        #::server{:connector     {::http/port 3000}
-                 :handler       {::context/ring-handler               (app/handler)
-                                 ::security/handler                   :oidc
-                                 ::session/enabled?                   false
-                                 ::oidc/authorization-flow            :client-credentials
-                                 ::oidc.jwk/source                    :rsa
-                                 ::oidc.jwk.rsa/key                   rsa-key
-                                 ::oidc.jwt.at.verification/exact-iss "http://localhost:8080/realms/master"
-                                 ::oidc.jwt.at.verification/exact-aud "https://slipway.io/api" ;; <-- set in keycloak-realms-with-client.json
-                                 ::oidc/constraint-mappings           app/constraints}
+                 :handler       {::context/ring-handler                       (app/handler)
+                                 ::security/handler                           :oidc
+                                 ::session/enabled?                           false
+                                 ::oidc/authorization-flow                    :client-credentials
+                                 ::oidc.jwk/source                            :rsa
+                                 ::oidc.jwk.rsa/key                           rsa-key
+                                 ::oidc.jwt.at.verification/required-issuer   "http://localhost:8080/realms/master"
+                                 ::oidc.jwt.at.verification/required-audience "https://slipway.io/api" ;; <-- set in keycloak-realms-with-client.json
+                                 ::oidc/constraint-mappings                   app/constraints}
                  :error-handler app/server-error-handler})
 
       (testing "no authorization header"

--- a/test/integration/slipway/test_server.clj
+++ b/test/integration/slipway/test_server.clj
@@ -61,14 +61,14 @@
 (defn start-with-openid-client-creds!
   []
   (start! #::server{:connector     {::http/port 3000}
-                    :handler       {::context/ring-handler               (app/handler)
-                                    ::security/handler                   :oidc
-                                    ::session/enabled?                   false
-                                    ::oidc/authorization-flow            :client-credentials
-                                    ::oidc/constraint-mappings           app/constraints
-                                    ::oidc.jwks/uri                      "http://localhost:8080/realms/master/protocol/openid-connect/certs"
-                                    ::oidc.jwt.at.verification/exact-iss "http://localhost:8080/realms/master" ;; <-- set in keycloak-realms-with-client.json
-                                    ::oidc.jwt.at.verification/exact-aud "https://slipway.io/api"
-                                    ::oidc.jwt/user-id-path              ["preferred_username"]
-                                    ::oidc.jwt/user-roles-path           ["realm_access" "roles"]}
+                    :handler       {::context/ring-handler                       (app/handler)
+                                    ::security/handler                           :oidc
+                                    ::session/enabled?                           false
+                                    ::oidc/authorization-flow                    :client-credentials
+                                    ::oidc/constraint-mappings                   app/constraints
+                                    ::oidc.jwks/uri                              "http://localhost:8080/realms/master/protocol/openid-connect/certs"
+                                    ::oidc.jwt.at.verification/required-issuer   "http://localhost:8080/realms/master" ;; <-- set in keycloak-realms-with-client.json
+                                    ::oidc.jwt.at.verification/required-audience "https://slipway.io/api"
+                                    ::oidc.jwt/user-id-path                      ["preferred_username"]
+                                    ::oidc.jwt/user-roles-path                   ["realm_access" "roles"]}
                     :error-handler app/server-error-handler}))

--- a/test/unit/slipway/security/oidc/jwt/at/verification_test.clj
+++ b/test/unit/slipway/security/oidc/jwt/at/verification_test.clj
@@ -17,45 +17,45 @@
 
   ;; common override to support "JWT"
   (is (= #{"JWT"}
-         (->> ^DefaultJOSEObjectTypeVerifier (verification/type-verifier {::verification/exact-typ ["JWT"]})
+         (->> ^DefaultJOSEObjectTypeVerifier (verification/type-verifier {::verification/allowed-types ["JWT"]})
               (.getAllowedTypes)
               (map #(.getType %1))
               set))))
 
 (deftest claims-verifier
 
-  (testing "required exact-iss"
-    (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/exact-aud "http://slipway-api"}))))
+  (testing "required issuer"
+    (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/required-audience "http://slipway-api"}))))
 
-  (testing "required exact-aud"
-    (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/exact-iss "http://oidc-idp"}))))
+  (testing "required audience"
+    (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/required-issuer "http://oidc-idp"}))))
 
   (testing "required claims"
 
     ;; default required claims
-    (is (= #{"aud"                                          ;; <-- required due to exact-iss
-             "iss"                                          ;; <-- required due to exact-aud
+    (is (= #{"aud"                                          ;; <-- required due to required-audience
+             "iss"                                          ;; <-- required due to required-issuer
              "exp"                                          ;; <-- here and below, default required claims set
              "iat"
              "jti"
              "sub"}
            (->> ^DefaultJWTClaimsVerifier (verification/claims-verifier
-                                           {::verification/exact-iss "http://oidc-idp"
-                                            ::verification/exact-aud "http://slipway-api"})
+                                           {::verification/required-issuer   "http://oidc-idp"
+                                            ::verification/required-audience "http://slipway-api"})
                 (.getRequiredClaims)
                 set)))
 
     ;; specific required claims
-    (is (= #{"aud"                                          ;; <-- required due to exact-iss
-             "iss"                                          ;; <-- required due to exact-aud
+    (is (= #{"aud"                                          ;; <-- required due to required audience
+             "iss"                                          ;; <-- required due to required issuer
              "exp"                                          ;; <-- here and below, specific required claims set
              "iat"
              "sub"}
            (->> ^DefaultJWTClaimsVerifier (verification/claims-verifier
-                                           {::verification/exact-iss       "http://oidc-idp"
-                                            ::verification/exact-aud       "http://slipway-api"
-                                            ::verification/required-claims #{JWTClaimNames/SUBJECT
-                                                                             JWTClaimNames/ISSUED_AT
-                                                                             JWTClaimNames/EXPIRATION_TIME}})
+                                           {::verification/required-issuer   "http://oidc-idp"
+                                            ::verification/required-audience "http://slipway-api"
+                                            ::verification/required-claims   #{JWTClaimNames/SUBJECT
+                                                                               JWTClaimNames/ISSUED_AT
+                                                                               JWTClaimNames/EXPIRATION_TIME}})
                 (.getRequiredClaims)
                 set)))))

--- a/test/unit/slipway/security/oidc/jwt/at_test.clj
+++ b/test/unit/slipway/security/oidc/jwt/at_test.clj
@@ -35,19 +35,19 @@
 
 (deftest processor-creation
 
-  (testing "missing required exact-iss"
+  (testing "missing required issuer"
     (is (thrown? ExceptionInfo
                  (jwt.at/processor
                   (jwk/source {::jwk/source  :rsa
                                ::jwk.rsa/key (jwk.rsa/jwk {})})
-                  {::jwt.at.verification/exact-aud "https://slipway.io/api"}))))
+                  {::jwt.at.verification/required-audience "https://slipway.io/api"}))))
 
-  (testing "missing required exact-aud"
+  (testing "missing required audience"
     (is (thrown? ExceptionInfo
                  (jwt.at/processor
                   (jwk/source {::jwk/source  :rsa
                                ::jwk.rsa/key (jwk.rsa/jwk {})})
-                  {::jwt.at.verification/exact-iss "http://localhost:8080/realms/master"})))))
+                  {::jwt.at.verification/required-issuer "http://localhost:8080/realms/master"})))))
 
 (deftest processor-defaults
 
@@ -56,8 +56,8 @@
         processor (jwt.at/processor
                    (jwk/source {::jwk/source  :rsa
                                 ::jwk.rsa/key rsa-key})
-                   {::jwt.at.verification/exact-iss "http://localhost:8080/realms/master"
-                    ::jwt.at.verification/exact-aud "https://slipway.io/api"})]
+                   {::jwt.at.verification/required-issuer   "http://localhost:8080/realms/master"
+                    ::jwt.at.verification/required-audience "https://slipway.io/api"})]
 
     (testing "all valid defaults met"
 
@@ -90,8 +90,8 @@
                    (-> (.process (jwt.at/processor
                                   (jwk/source {::jwk/source  :rsa
                                                ::jwk.rsa/key (jwk.rsa/jwk {})})
-                                  {::jwt.at.verification/exact-iss "http://localhost:8080/realms/master"
-                                   ::jwt.at.verification/exact-aud "https://slipway.io/api"})
+                                  {::jwt.at.verification/required-issuer   "http://localhost:8080/realms/master"
+                                   ::jwt.at.verification/required-audience "https://slipway.io/api"})
                                  (signed-jwt rsa-key
                                              {:typ "at+jwt"
                                               :iss "http://localhost:8080/realms/master"


### PR DESCRIPTION
Change `:slipway.security.oidc.jwt.at.verification` configuration from:

```clojure
#:slipway.security.oidc.jwt.at.verification
  {::exact-typ       "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
   ::exact-iss       "required: the URL of the OIDC provider"
   ::exact-aud       "required: the audience of this service to match the 'aud' field in the jwt"
   ::required-claims "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
```

To:

```clojure
#:slipway.security.oidc.jwt.at.verification
  {::allowed-types     "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
   ::required-issuer   "required: the URL of the OIDC provider"
   ::required-audience "required: the audience of this service to match the 'aud' field in the jwt"
   ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
```