### PR TITLE
Access Token Validation Flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,9 +798,9 @@ verified. This configuration gives you the flexibility required to ensure the ac
 
 ```clojure
 #:slipway.security.oidc.jwt.at.verification
-        {::allowed-types     "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
-         ::required-issuer   "required: the URL of the OIDC provider"
-         ::required-audience "required: the audience of this service to match the 'aud' field in the jwt"
+        {::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
+         ::required-issuer   "the issuer identifier for the authorization server, presented as 'iss' in the JWT"
+         ::required-audience "a resource indicator value corresponding to an identifier the resource server expects for itself, presented as 'aud' in the JWT"
          ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -797,11 +797,11 @@ verified. This configuration gives you the flexibility required to ensure the ac
 #### slipway.security.oidc.jwt.at.verification configuration
 
 ```clojure
-#:slipway.security.oidc.jwt.at.verification
-        {::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
-         ::required-issuer   "the issuer identifier for the authorization server, presented as 'iss' in the JWT"
-         ::required-audience "a resource indicator value corresponding to an identifier the resource server expects for itself, presented as 'aud' in the JWT"
-         ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
+#:slipway.security.oidc.jwt.at.verification{::vendor            "(optional) switch to a specific vendor verification implementation"
+                                            ::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
+                                            ::required-issuer   "the issuer identifier for the authorization server, presented as 'iss' in the JWT"
+                                            ::required-audience "a resource indicator value corresponding to an identifier the resource server expects for itself, presented as 'aud' in the JWT"
+                                            ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
 ```
 
 ### [ns: slipway.security.oidc.jwk](src/slipway/security/oidc/jwks.clj)

--- a/src/slipway.clj
+++ b/src/slipway.clj
@@ -128,7 +128,8 @@
                               :user-id-path           "the path within the source token to find user name, default is ['sub']"
                               :user-expiration-source "the token used for session expiration, either 'access_token' or 'id_token' (default is 'access_token')"}
 
-  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
+  #:slipway.security.oidc.jwt.at.verification{::vendor            "(optional) switch to a specific vendor verification implementation"
+                                              ::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
                                               ::required-issuer   "the issuer identifier for the authorization server, presented as 'iss' in the JWT"
                                               ::required-audience "a resource indicator value corresponding to an identifier the resource server expects for itself, presented as 'aud' in the JWT"
                                               ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}

--- a/src/slipway.clj
+++ b/src/slipway.clj
@@ -128,9 +128,9 @@
                               :user-id-path           "the path within the source token to find user name, default is ['sub']"
                               :user-expiration-source "the token used for session expiration, either 'access_token' or 'id_token' (default is 'access_token')"}
 
-  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
-                                              ::required-issuer   "required: the URL of the OIDC provider"
-                                              ::required-audience "required: the audience of this service to match the 'aud' field in the jwt"
+  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
+                                              ::required-issuer   "the issuer identifier for the authorization server, presented as 'iss' in the JWT"
+                                              ::required-audience "a resource indicator value corresponding to an identifier the resource server expects for itself, presented as 'aud' in the JWT"
                                               ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"}
 
   #:slipway.session{:enabled?                "are sessions enabled for this server? Default true"

--- a/src/slipway/compression.clj
+++ b/src/slipway/compression.clj
@@ -1,7 +1,8 @@
 (ns slipway.compression
   (:refer-clojure :exclude [format])
   (:require [clojure.tools.logging :as log])
-  (:import (org.eclipse.jetty.compression.gzip GzipCompression)
+  (:import (org.eclipse.jetty.compression Compression)
+           (org.eclipse.jetty.compression.gzip GzipCompression)
            (org.eclipse.jetty.compression.server CompressionConfig CompressionHandler)))
 
 (comment
@@ -11,7 +12,7 @@
                         :compress-min-bytes "min response size to trigger compression (default 1024 bytes)"
                         :compression-config "a concrete Jetty CompressionConfig instance (nil for default configuration)"})
 
-(defmulti format ::format)
+(defmulti ^Compression format ::format)
 
 (defmethod format :default
   [_opts]

--- a/src/slipway/security/oidc/jwt/at.clj
+++ b/src/slipway/security/oidc/jwt/at.clj
@@ -2,7 +2,8 @@
   (:require [slipway.security.oidc.jwk :as jwk]
             [slipway.security.oidc.jwk.source :as jwk.source]
             [slipway.security.oidc.jws :as jws]
-            [slipway.security.oidc.jwt.at.verification :as verification])
+            [slipway.security.oidc.jwt.at.verification :as verification]
+            [slipway.security.oidc.jwt.at.verification.cognito])
   (:import (com.nimbusds.jwt.proc DefaultJWTProcessor JWTProcessor)
            (slipway.security.oidc.jwt JWTProcessorBean)))
 

--- a/src/slipway/security/oidc/jwt/at/verification.clj
+++ b/src/slipway/security/oidc/jwt/at/verification.clj
@@ -6,16 +6,22 @@
            (com.nimbusds.jwt.proc DefaultJWTClaimsVerifier)
            (java.util Set)))
 
-;; https://datatracker.ietf.org/doc/html/rfc9068#section-2.1
-;; typ MUST conform to "application/at+jwt", RECOMMENDED that "application/" be ommitted
-;; Keycloak (and possibly other IdP) encodes "JWT" at token type, you can encode that here or:
-;;  - https://www.keycloak.org/2025/04/keycloak-2620-released
-;;  - see: New client configuration for access token header type
-;;  - set "access.token.header.type.rfc9068": "true" in ["client" "attributes"] to have Keycloak conform to the RFC
+;; This namespace provides functions that verify OAuth 2.0 Access Tokens via the JOSE Nimbus library
 
+;; The rules for validating tokens per the RFC are broadly:
+;; https://datatracker.ietf.org/doc/html/rfc9068#section-2.1, and
+;; https://datatracker.ietf.org/doc/html/rfc9068#section-4
+
+;; However, in reality many commercial IDP don't strictly follow these rules, including both
+;; Microsoft Entra ID and Keycloak regarding the JWT typ field in the header:
+;;
+;; https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference
+;; https://www.keycloak.org/2025/04/keycloak-2620-released
+;;
+;; For this reason, the functions here also default to some generally accepted varations.
 (defn type-verifier ^JOSEObjectTypeVerifier
   [{::keys [allowed-types]
-    :or    {allowed-types ["at+jwt" "application/at+jwt"]}}]
+    :or    {allowed-types ["JWT" "at+jwt" "application/at+jwt"]}}] ;; we include "JWT" extra to RFC, note above.
   (let [^Set object-types-set (set (map #(JOSEObjectType. %1) allowed-types))]
     (log/debugf "creating type-verifier with allowed types %s" (mapv #(.getType %1) object-types-set))
     (DefaultJOSEObjectTypeVerifier. object-types-set)))
@@ -38,7 +44,7 @@
    required-claims))
 
 (comment
-  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['at+jwt' 'application/at+jwt']"
-                                              ::required-issuer   "required: the URL of the OIDC provider"
-                                              ::required-audience "required: the audience of this service to match the 'aud' field in the jwt"
+  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
+                                              ::required-issuer   "the issuer identifier for the authorization server, presented as 'iss' in the JWT"
+                                              ::required-audience "a resource indicator value corresponding to an identifier the resource server expects for itself, presented as 'aud' in the JWT"
                                               ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"})

--- a/src/slipway/security/oidc/jwt/at/verification.clj
+++ b/src/slipway/security/oidc/jwt/at/verification.clj
@@ -24,10 +24,10 @@
 (defmulti ^JWTClaimsSetVerifier claims-verifier ::vendor)
 
 (defmethod type-verifier :default
-  [{::keys [allowed-types]
+  [{::keys [allowed-types vendor]
     :or    {allowed-types ["JWT" "at+jwt" "application/at+jwt"]}}] ;; we include "JWT" extra to RFC, note above.
   (let [^Set object-types-set (set (map #(JOSEObjectType. %1) allowed-types))]
-    (log/debugf "creating type-verifier with allowed types %s" (mapv #(.getType %1) object-types-set))
+    (log/debugf "creating default type-verifier with allowed types %s" vendor)
     (DefaultJOSEObjectTypeVerifier. object-types-set)))
 
 (defmethod claims-verifier :default
@@ -38,7 +38,7 @@
                               JWTClaimNames/EXPIRATION_TIME}}}]
   (when-not required-issuer (throw (ex-info "missing required configuration: required-issuer" {})))
   (when-not required-audience (throw (ex-info "missing required configuration: required-audience" {})))
-  (log/debugf "creating claims-verifier for issuer %s and audience %s" required-issuer required-audience)
+  (log/debugf "creating default claims-verifier for issuer %s and audience %s" required-issuer required-audience)
   (DefaultJWTClaimsVerifier.
    required-audience
    (-> (JWTClaimsSet$Builder.)

--- a/src/slipway/security/oidc/jwt/at/verification.clj
+++ b/src/slipway/security/oidc/jwt/at/verification.clj
@@ -3,7 +3,7 @@
   (:import (com.nimbusds.jose JOSEObjectType)
            (com.nimbusds.jose.proc DefaultJOSEObjectTypeVerifier JOSEObjectTypeVerifier)
            (com.nimbusds.jwt JWTClaimNames JWTClaimsSet$Builder)
-           (com.nimbusds.jwt.proc DefaultJWTClaimsVerifier)
+           (com.nimbusds.jwt.proc DefaultJWTClaimsVerifier JWTClaimsSetVerifier)
            (java.util Set)))
 
 ;; This namespace provides functions that verify OAuth 2.0 Access Tokens via the JOSE Nimbus library
@@ -19,15 +19,18 @@
 ;; https://www.keycloak.org/2025/04/keycloak-2620-released
 ;;
 ;; For this reason, the functions here also default to some generally accepted varations.
-(defn type-verifier ^JOSEObjectTypeVerifier
+
+(defmulti ^JOSEObjectTypeVerifier type-verifier ::vendor)
+(defmulti ^JWTClaimsSetVerifier claims-verifier ::vendor)
+
+(defmethod type-verifier :default
   [{::keys [allowed-types]
     :or    {allowed-types ["JWT" "at+jwt" "application/at+jwt"]}}] ;; we include "JWT" extra to RFC, note above.
   (let [^Set object-types-set (set (map #(JOSEObjectType. %1) allowed-types))]
     (log/debugf "creating type-verifier with allowed types %s" (mapv #(.getType %1) object-types-set))
     (DefaultJOSEObjectTypeVerifier. object-types-set)))
 
-(defn claims-verifier
-  "A claims verifier for OAuth 2.0 access tokens"
+(defmethod claims-verifier :default
   [{::keys [required-issuer required-audience required-claims]
     :or    {required-claims #{JWTClaimNames/JWT_ID
                               JWTClaimNames/SUBJECT
@@ -44,7 +47,8 @@
    required-claims))
 
 (comment
-  #:slipway.security.oidc.jwt.at.verification{::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
+  #:slipway.security.oidc.jwt.at.verification{::vendor            "(optional) switch to a specific vendor verification implementation"
+                                              ::allowed-types     "a sequence of acceptable 'typ' fields, default is ['JWT' 'at+jwt' 'application/at+jwt']"
                                               ::required-issuer   "the issuer identifier for the authorization server, presented as 'iss' in the JWT"
                                               ::required-audience "a resource indicator value corresponding to an identifier the resource server expects for itself, presented as 'aud' in the JWT"
                                               ::required-claims   "set of required JWTClaimNames. Default #{JWTClaimNames/JWT_ID JWTClaimNames/SUBJECT JWTClaimNames/ISSUED_AT JWTClaimNames/EXPIRATION_TIME}"})

--- a/src/slipway/security/oidc/jwt/at/verification/cognito.clj
+++ b/src/slipway/security/oidc/jwt/at/verification/cognito.clj
@@ -1,0 +1,39 @@
+(ns slipway.security.oidc.jwt.at.verification.cognito
+  (:require [clojure.tools.logging :as log]
+            [slipway.security.oidc.jwt.at.verification :as verification])
+  (:import (com.nimbusds.jose.proc DefaultJOSEObjectTypeVerifier)
+           (com.nimbusds.jwt JWTClaimNames JWTClaimsSet$Builder)
+           (com.nimbusds.jwt.proc DefaultJWTClaimsVerifier)))
+
+;; This namespace provides functions that verify Amazon Cognito Access Tokens via the JOSE Nimbus library
+
+;; The rules for validating Amazon Cognito tokens differ from the OAuth 2.0 JWT RFC:
+;;
+;; See: 'validate the JWT' and 'verify the claims'
+;;   https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html
+
+;; See: 'Verified Permissions compares this list of app client IDs to the ID token aud claim or the access token client_id claim'
+;;   https://docs.aws.amazon.com/verifiedpermissions/latest/userguide/cognito-validation.html
+
+(defmethod verification/type-verifier :amazon-cognito
+  [_opts]
+  (log/debug "creating amazon cognito type-verifier")
+  ;; Amazon Cognito JWT do not include a 'typ' header
+  (DefaultJOSEObjectTypeVerifier.))
+
+(defmethod verification/claims-verifier :amazon-cognito
+  [{::verification/keys [required-issuer required-audience required-claims]
+    :or                 {required-claims #{JWTClaimNames/JWT_ID
+                                           JWTClaimNames/SUBJECT
+                                           JWTClaimNames/ISSUED_AT
+                                           JWTClaimNames/EXPIRATION_TIME}}}]
+  (when-not required-issuer (throw (ex-info "missing required configuration: required-issuer" {})))
+  (when-not required-audience (throw (ex-info "missing required configuration: required-audience" {})))
+  (log/debugf "creating amazon cognito claims-verifier for issuer %s and client_id %s" required-issuer required-audience)
+  (DefaultJWTClaimsVerifier.
+   (-> (JWTClaimsSet$Builder.)
+       (.issuer required-issuer)
+       (.claim "client_id" required-audience)               ;; Amazon Cognito AT include the audience as the 'client_id' claim
+       (.claim "token_use" "access")                        ;; Amazon Cognito AT require the verification of the 'token_use' field
+       (.build))
+   required-claims))

--- a/test/unit/slipway/security/oidc/jwt/at/verification/cognito_test.clj
+++ b/test/unit/slipway/security/oidc/jwt/at/verification/cognito_test.clj
@@ -1,0 +1,70 @@
+(ns slipway.security.oidc.jwt.at.verification.cognito-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [slipway.security.oidc.jwt.at.verification :as verification]
+            [slipway.security.oidc.jwt.at.verification.cognito])
+  (:import (clojure.lang ExceptionInfo)
+           (com.nimbusds.jose.proc DefaultJOSEObjectTypeVerifier)
+           (com.nimbusds.jwt JWTClaimNames)
+           (com.nimbusds.jwt.proc DefaultJWTClaimsVerifier)))
+
+(deftest type-verifier
+
+  ;; default allowable 'typ' fields
+  (is (= #{nil}                                             ;; not quite sure why the odd #{nil} here but it's the impl
+         (->> ^DefaultJOSEObjectTypeVerifier (verification/type-verifier {::verification/vendor :amazon-cognito})
+              (.getAllowedTypes))))
+
+  ;; configured allowed-types are ignored for cognito
+  (is (= #{nil}
+         (->> ^DefaultJOSEObjectTypeVerifier (verification/type-verifier {::verification/vendor        :amazon-cognito
+                                                                          ::verification/allowed-types ["abc" "efg"]})
+              (.getAllowedTypes)))))
+
+(deftest claims-verifier
+
+  (testing "both required available"
+    (is (not (nil? (verification/claims-verifier {::verification/vendor            :amazon-cognito
+                                                  ::verification/required-issuer   "http://oidc-idp"
+                                                  ::verification/required-audience "http://slipway-api"})))))
+
+  (testing "required issuer throws"
+    (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/vendor            :amazon-cognito
+                                                              ::verification/required-audience "http://slipway-api"}))))
+
+  (testing "required audience throws (inbound-config check only, is applied as client_id in the actual verifier)"
+    (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/vendor          :amazon-cognito
+                                                              ::verification/required-issuer "http://oidc-idp"}))))
+
+  (testing "required claims"
+
+    ;; default required claims
+    (is (= #{"client_id"                                    ;; <-- required by amazon cognito
+             "token_use"                                    ;; <-- required by amazon cognito
+             "iss"                                          ;; <-- required due to required-issuer
+             "exp"                                          ;; <-- here and below, default required claims set
+             "iat"
+             "sub"
+             "jti"}
+           (->> ^DefaultJWTClaimsVerifier (verification/claims-verifier
+                                           {::verification/vendor            :amazon-cognito
+                                            ::verification/required-issuer   "http://oidc-idp"
+                                            ::verification/required-audience "http://slipway-api"})
+                (.getRequiredClaims)
+                set)))
+
+    ;; specific required claims (removing jti)
+    (is (= #{"client_id"                                    ;; <-- required by amazon cognito
+             "token_use"                                    ;; <-- required by amazon cognito
+             "iss"                                          ;; <-- required due to required-issuer
+             "exp"                                          ;; <-- here and below, default required claims set
+             "iat"
+             "sub"}
+           (->> ^DefaultJWTClaimsVerifier (verification/claims-verifier
+                                           {::verification/vendor            :amazon-cognito
+                                            ::verification/required-issuer   "http://oidc-idp"
+                                            ::verification/required-audience "http://slipway-api"
+                                            ::verification/required-claims   #{JWTClaimNames/SUBJECT
+                                                                               JWTClaimNames/ISSUED_AT
+                                                                               JWTClaimNames/EXPIRATION_TIME}})
+                (.getRequiredClaims)
+                set)))))

--- a/test/unit/slipway/security/oidc/jwt/at/verification_test.clj
+++ b/test/unit/slipway/security/oidc/jwt/at/verification_test.clj
@@ -24,10 +24,14 @@
 
 (deftest claims-verifier
 
-  (testing "required issuer"
+  (testing "both required available"
+    (is (not (nil? (verification/claims-verifier {::verification/required-issuer   "http://oidc-idp"
+                                                  ::verification/required-audience "http://slipway-api"})))))
+
+  (testing "required issuer throws"
     (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/required-audience "http://slipway-api"}))))
 
-  (testing "required audience"
+  (testing "required audience throws"
     (is (thrown? ExceptionInfo (verification/claims-verifier {::verification/required-issuer "http://oidc-idp"}))))
 
   (testing "required claims"
@@ -45,7 +49,7 @@
                 (.getRequiredClaims)
                 set)))
 
-    ;; specific required claims
+    ;; specific required claims (removing jti)
     (is (= #{"aud"                                          ;; <-- required due to required audience
              "iss"                                          ;; <-- required due to required issuer
              "exp"                                          ;; <-- here and below, specific required claims set

--- a/test/unit/slipway/security/oidc/jwt/at/verification_test.clj
+++ b/test/unit/slipway/security/oidc/jwt/at/verification_test.clj
@@ -9,15 +9,15 @@
 (deftest type-verifier
 
   ;; default allowable 'typ' fields
-  (is (= #{"at+jwt" "application/at+jwt"}
+  (is (= #{"JWT" "at+jwt" "application/at+jwt"}
          (->> ^DefaultJOSEObjectTypeVerifier (verification/type-verifier {})
               (.getAllowedTypes)
               (map #(.getType %1))
               set)))
 
-  ;; common override to support "JWT"
-  (is (= #{"JWT"}
-         (->> ^DefaultJOSEObjectTypeVerifier (verification/type-verifier {::verification/allowed-types ["JWT"]})
+  ;; can override to support anything
+  (is (= #{"abc" "efg"}
+         (->> ^DefaultJOSEObjectTypeVerifier (verification/type-verifier {::verification/allowed-types ["abc" "efg"]})
               (.getAllowedTypes)
               (map #(.getType %1))
               set))))


### PR DESCRIPTION
* Support "JWT" in default at/typ set
* Support specific Amazon Cognito AT verification